### PR TITLE
fix(webapp): guard CurrentTeam before reading display_name (plugin crashes on cold load)

### DIFF
--- a/webapp/src/components/event.tsx
+++ b/webapp/src/components/event.tsx
@@ -666,7 +666,7 @@ const EventModalComponent = () => {
                                     </div>
                                 </div>
                                 <div className="current-team-tag">
-                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam.display_name}</Tag>
+                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam?.display_name}</Tag>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Problem

Loading Mattermost directly on the `/calendar` route crashes the plugin:

```
TypeError: Cannot read properties of undefined (reading 'display_name')
    at DN (com.dmkir.calendar_<hash>_bundle.js)
    at ao (react-dom.production.min.js)
    ...
    at componentDidMount (root.tsx:412)
```

React unmounts the plugin and the user sees **"An error occurred in the com.dmkir.calendar plugin. Refresh?"**.

## Cause

`webapp/src/components/event.tsx:669`:

```jsx
<Tag icon={<PeopleTeam24Regular />}>{CurrentTeam.display_name}</Tag>
```

`CurrentTeam` comes from the `getCurrentTeam` selector, which returns `undefined` until `entities.teams` is hydrated.

Two things combine to make that reachable:

1. `MainApp` (`app.tsx`) **always** renders `<EventModalComponent/>` — it is not conditional.
2. The JSX inside `<Dialog open={isOpenEventModal}>` is still evaluated on every render even while the dialog is **closed**, so line 669 runs even if the user never opens the event modal.

So on a cold load the component renders before team data arrives, `CurrentTeam` is `undefined`, and reading `.display_name` throws during the initial mount.

This is why it presents as intermittent: navigating into the calendar *after* teams are loaded works fine, and a refresh often appears to "fix" it — it is a race, not a persistent state.

## Fix

Optional chaining. The tag renders empty for the one frame before teams arrive, then the real team name on the next render.

```diff
-<Tag icon={<PeopleTeam24Regular />}>{CurrentTeam.display_name}</Tag>
+<Tag icon={<PeopleTeam24Regular />}>{CurrentTeam?.display_name}</Tag>
```

## Verification

Reproduced on **0.6.2** against **Mattermost 9.9.3** (Team Edition). Built the patched webapp bundle, swapped it into the 0.6.2 release, and installed it — the crash is gone and the calendar loads reliably on a cold start, including landing directly on `/calendar`.

The same unguarded access is present on `main`, so current releases are affected too.