### PR TITLE
fix(webapp): day headers show the previous day for users west of UTC

### DIFF
--- a/webapp/src/components/calendar-content.tsx
+++ b/webapp/src/components/calendar-content.tsx
@@ -150,10 +150,10 @@ const CalendarContent = () => {
                         const showDay = CalendarRef.current?.getApi().view.type !== 'dayGridMonth';
                         return (<>
                             <div className={`custom-day-header  ${dayHeaderProps.isToday ? 'custom-day-today' : ''}`}>
-                                {showDay ? <div className='custom-day-header-day'>{dayHeaderProps.date.getDate()}</div> : ''}
+                                {showDay ? <div className='custom-day-header-day'>{dayHeaderProps.date.getUTCDate()}</div> : ''}
                                 <div
                                     className='custom-day-header-weekday'
-                                >{dayOfWeekAsString(dayHeaderProps.date.getDay())}</div>
+                                >{dayOfWeekAsString(dayHeaderProps.date.getUTCDay())}</div>
                             </div>
                         </>);
                     }}


### PR DESCRIPTION
## Problem

Every user in a timezone **behind UTC** sees the wrong date in the calendar's day headers — the column highlighted as *today* displays **yesterday's** number.

Reported by a user in `America/New_York` as "the calendar keeps showing yesterday as today".

## Cause

`webapp/src/components/calendar-content.tsx` configures FullCalendar with a **named** timezone:

```jsx
timeZone={getUserTimeZoneString()}
```

Under a named timezone, FullCalendar passes callbacks **UTC-coerced marker dates** — the `Date`'s *UTC* fields carry the zoned wall-clock value. But `dayHeaderContent` reads them with local getters:

```jsx
{dayHeaderProps.date.getDate()}                   // browser-local
dayOfWeekAsString(dayHeaderProps.date.getDay())   // browser-local
```

which apply the **browser's** offset on top of the marker.

For a browser at UTC−4, the marker for Aug 26 is `2026-08-26T00:00:00Z`; `.getDate()` evaluates that as **Aug 25, 20:00** and renders `25`.

`dayHeaderProps.isToday` is FullCalendar's own flag and remains correct — so the *highlight* sits on the right column while the *number* inside it is off by one, which is what makes it read as "yesterday shown as today".

| Browser TZ | `getDate()` | `getUTCDate()` | |
|---|---|---|---|
| UTC−4 (New York) | 25 | 26 | ❌ |
| UTC−7 (Los Angeles) | 25 | 26 | ❌ |
| UTC+2 (Madrid) | 26 | 26 | ✅ |
| UTC+3 (Moscow) | 26 | 26 | ✅ |

Only timezones behind UTC are affected — at UTC+ the marker stays on the same calendar day, which is likely why this hasn't been reported before.

## Fix

Use the UTC getters, which is the documented way to read marker dates:

```diff
-{dayHeaderProps.date.getDate()}
+{dayHeaderProps.date.getUTCDate()}
-dayOfWeekAsString(dayHeaderProps.date.getDay())
+dayOfWeekAsString(dayHeaderProps.date.getUTCDay())
```

## Verification

Built and deployed against **Mattermost 9.9.3** with a **UTC−4** browser: day numbers and weekday labels now match the highlighted day.

Independent of #53 (the `CurrentTeam` crash), though both ship in the same build here.