### PR TITLE
fix(webapp): channel picker shows "No results found" until you type, and offers archived channels

### DIFF
--- a/webapp/src/components/event.tsx
+++ b/webapp/src/components/event.tsx
@@ -692,7 +692,7 @@ const EventModalComponent = () => {
                                     </div>
                                 </div>
                                 <div className="current-team-tag">
-                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam?.display_name}</Tag>
+                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam.display_name}</Tag>
                                 </div>
                             </div>
 

--- a/webapp/src/components/event.tsx
+++ b/webapp/src/components/event.tsx
@@ -235,14 +235,39 @@ const EventModalComponent = () => {
         });
     };
 
+    // Archived channels must never be offered: an event attached to one is invisible
+    // to everybody. Mattermost's autocomplete returns them, so filter here.
+    const notArchived = (list) => (list || []).filter((c) => !c.delete_at);
+
     const onInputChannelAction = async (event: React.ChangeEvent<HTMLInputElement>) => {
         setSelectedChannelText(event.target.value);
         if (event.target.value !== '') {
             const resp = await Client4.autocompleteChannels(CurrentTeamId, event.target.value);
-            setChannelsAutocomplete(resp);
+            setChannelsAutocomplete(notArchived(resp));
         } else {
-            // if channel input empty, remove selected channel
+            // if channel input empty, remove selected channel and show the full list
             setSelectedChannel({});
+            loadMyChannels();
+        }
+    };
+
+    // Populate the dropdown when it is opened with an empty box. Without this the
+    // list is only ever filled by onChange, so opening the picker shows a bare
+    // "No results found" until the user guesses that they have to type.
+    const loadMyChannels = async () => {
+        try {
+            const mine = await Client4.getMyChannels(CurrentTeamId);
+            setChannelsAutocomplete(
+                notArchived(mine).filter((c) => c.type === 'O' || c.type === 'P'),
+            );
+        } catch (e) {
+            // leave the list as-is; typing still works
+        }
+    };
+
+    const onChannelOpenChange = (event, data) => {
+        if (data.open && selectedChannelText === '') {
+            loadMyChannels();
         }
     };
 
@@ -641,6 +666,7 @@ const EventModalComponent = () => {
                                             <Combobox
                                                 placeholder='Select a channel'
                                                 onChange={onInputChannelAction}
+                                                onOpenChange={onChannelOpenChange}
                                                 onOptionSelect={onSelectChannelOption}
                                                 value={selectedChannelText}
                                             >
@@ -666,7 +692,7 @@ const EventModalComponent = () => {
                                     </div>
                                 </div>
                                 <div className="current-team-tag">
-                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam.display_name}</Tag>
+                                <Tag icon={<PeopleTeam24Regular />}>{CurrentTeam?.display_name}</Tag>
                                 </div>
                             </div>
 


### PR DESCRIPTION
Two problems with the event modal's channel selector, both hit while setting up channel-visibility events.

## 1. Opening the picker shows "No results found"

`channelsAutocomplete` is populated **only** by `onInputChannelAction` (`onChange`). With an empty input the array is `[]`, so the component renders its no-results `Option`:

```jsx
{channelsAutocomplete.length === 0 ? (
    <Option key='no-results' text=''>No results found</Option>
) : null}
```

Nothing signals that typing is required, so the control reads as broken — and with it the whole Channel visibility feature, since `visibility=channel` can't be saved without a channel (the server enforces `Channel is required for channel visibility`).

**Fix:** an `onOpenChange` handler that loads the user's channels via `Client4.getMyChannels` when the dropdown opens with an empty box. Clearing the input reloads the list instead of leaving it empty. Typing still narrows via autocomplete exactly as before.

## 2. The picker offers archived channels

Mattermost's autocomplete returns archived channels. Selecting one attaches the event to a channel nobody can see — a silent, data-loss-shaped failure with no feedback.

Reproduced on a live server: the autocomplete offered two channels that had been archived earlier the same day.

**Fix:** filter on `delete_at` in both the autocomplete and preload paths. The preloaded list is also restricted to `O`/`P` so DMs and GMs aren't offered as event channels.

## Verification

Built and deployed against **Mattermost 9.9.3**. Opening the picker now lists the user's channels immediately, archived channels no longer appear, and typing narrows as before.

Independent of #53 and #54, though all three ship in the same build here.