### PR TITLE
fix(server): events whose start minute is missed are never announced

### DIFF
--- a/server/background.go
+++ b/server/background.go
@@ -186,6 +186,24 @@ func (b *Background) process(t time.Time) {
 				sq.Eq{"ce.dt_start": tickWithZone},
 				sq.Eq{"ce.alert_time": tickWithZone},
 				recurrentTimeQuery,
+				// Catch-up: dt_start is matched for exact equality against a tick
+				// truncated to the minute, so an event whose minute the ticker never
+				// observed — server restart, plugin reload, a slow tick — is silently
+				// never announced. Re-check recent, never-processed one-off events so
+				// a missed minute is recovered instead of lost.
+				//
+				// Deliberately scoped:
+				//   recurrent = false — recurring rows keep their ORIGINAL dt_start and
+				//     rewrite the occurrence in memory, so a range match would re-fire
+				//     them forever after the first occurrence.
+				//   processed IS NULL — an event already announced is never repeated.
+				//   bounded window — never replays old history on startup.
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": tickWithZone.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": tickWithZone},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},

--- a/server/background_test.go
+++ b/server/background_test.go
@@ -247,6 +247,12 @@ func TestProcessEventWithChannel(t *testing.T) {
 				sq.Eq{"ce.dt_start": sqlQueryTime},
 				sq.Eq{"ce.alert_time": sqlQueryTime},
 				recurrentTimeQuery,
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": sqlQueryTime.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": sqlQueryTime},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},
@@ -257,7 +263,8 @@ func TestProcessEventWithChannel(t *testing.T) {
 
 	querySql, _, _ := queryBuilder.ToSql()
 	expectedQuery := dbMock.ExpectQuery(regexp.QuoteMeta(querySql)).
-		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime, sqlQueryTime)
+		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime,
+			false, sqlQueryTime.Add(-missedTickWindow), sqlQueryTime, sqlQueryTime)
 
 	eventsRow := sqlmock.NewRows([]string{
 		"id",
@@ -435,6 +442,12 @@ func TestProcessEventWithChannelRecurrent(t *testing.T) {
 				sq.Eq{"ce.dt_start": sqlQueryTime},
 				sq.Eq{"ce.alert_time": sqlQueryTime},
 				recurrentTimeQuery,
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": sqlQueryTime.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": sqlQueryTime},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},
@@ -445,7 +458,8 @@ func TestProcessEventWithChannelRecurrent(t *testing.T) {
 
 	querySql, _, _ := queryBuilder.ToSql()
 	expectedQuery := dbMock.ExpectQuery(regexp.QuoteMeta(querySql)).
-		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime, sqlQueryTime)
+		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime,
+			false, sqlQueryTime.Add(-missedTickWindow), sqlQueryTime, sqlQueryTime)
 
 	eventsRow := sqlmock.NewRows([]string{
 		"id",
@@ -622,6 +636,12 @@ func TestProcessCornerEventWithChannelRecurrent(t *testing.T) {
 				sq.Eq{"ce.dt_start": sqlQueryTime},
 				sq.Eq{"ce.alert_time": sqlQueryTime},
 				recurrentTimeQuery,
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": sqlQueryTime.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": sqlQueryTime},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},
@@ -632,7 +652,8 @@ func TestProcessCornerEventWithChannelRecurrent(t *testing.T) {
 
 	querySql, _, _ := queryBuilder.ToSql()
 	expectedQuery := dbMock.ExpectQuery(regexp.QuoteMeta(querySql)).
-		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime, sqlQueryTime)
+		WithArgs(sqlQueryTime, sqlQueryTime, true, sqlQueryTime, sqlQueryTime,
+			false, sqlQueryTime.Add(-missedTickWindow), sqlQueryTime, sqlQueryTime)
 
 	eventsRow := sqlmock.NewRows([]string{
 		"id",
@@ -792,6 +813,12 @@ func TestProcessEventWithoutChannel(t *testing.T) {
 				sq.Eq{"ce.dt_start": sqlQueryTime},
 				sq.Eq{"ce.alert_time": sqlQueryTime},
 				recurrentTimeQuery,
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": sqlQueryTime.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": sqlQueryTime},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},
@@ -807,6 +834,9 @@ func TestProcessEventWithoutChannel(t *testing.T) {
 			sqlQueryTime,
 			true,
 			sqlQueryTime,
+			sqlQueryTime,
+			false,
+			sqlQueryTime.Add(-missedTickWindow),
 			sqlQueryTime,
 			sqlQueryTime,
 		)
@@ -974,6 +1004,12 @@ func TestProcessEventWithChannelRecurrentNotDay(t *testing.T) {
 				sq.Eq{"ce.dt_start": sqlQueryTime},
 				sq.Eq{"ce.alert_time": sqlQueryTime},
 				recurrentTimeQuery,
+				sq.And{
+					sq.Eq{"ce.recurrent": false},
+					sq.Eq{"ce.processed": nil},
+					sq.Gt{"ce.dt_start": sqlQueryTime.Add(-missedTickWindow)},
+					sq.Lt{"ce.dt_start": sqlQueryTime},
+				},
 			},
 			sq.Or{
 				sq.Eq{"ce.processed": nil},
@@ -990,6 +1026,9 @@ func TestProcessEventWithChannelRecurrentNotDay(t *testing.T) {
 			sqlQueryTime,
 			true,
 			sqlQueryTime,
+			sqlQueryTime,
+			false,
+			sqlQueryTime.Add(-missedTickWindow),
 			sqlQueryTime,
 			sqlQueryTime,
 		)

--- a/server/constants.go
+++ b/server/constants.go
@@ -1,5 +1,12 @@
 package main
 
+import "time"
+
+// How far back the background job re-checks for one-off events whose exact
+// minute-tick was never observed (restart, reload, a slow tick). Bounded so a
+// restart never replays old history.
+const missedTickWindow = 10 * time.Minute
+
 const (
 	PluginId            = "com.dmkir.calendar"
 	EventDateTimeLayout = "2006-01-02T15:04:05"


### PR DESCRIPTION
## Problem

`Background.process` selects due events with **exact equality** against a tick truncated to the minute:

```go
tickWithZone := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), 0, 0, time.UTC)
...
sq.Eq{"ce.dt_start": tickWithZone},
```

The ticker fires every 15s, so an event is announced **only if some tick observes its exact minute**. If none does — server restart, plugin reload/upgrade, a slow or delayed tick — the event is skipped **permanently**. There's no catch-up: the row keeps `processed = NULL` and is never revisited. Nothing is logged, so it's silent.

Observed on a live server: a plugin upgrade restarted the process across an event's minute, and the channel post never arrived.

The same strictness also drops any event whose `dt_start` has **non-zero seconds**. The UI only produces `HH:MM:00`, so this is invisible there, but events created via the API with seconds set can never fire.

## Fix

A bounded catch-up branch alongside the existing ones, deliberately narrow:

| Condition | Why |
|---|---|
| `recurrent = false` | Recurring rows keep their **original** `dt_start` and rewrite the occurrence in memory — a range match would re-fire them on every tick after the first occurrence. |
| `processed IS NULL` | An event already announced is never repeated. |
| bounded window (10 min) | A restart never replays old history. |

The existing exact-equality branches are untouched, so `alert_time` and recurrence behaviour is unchanged.

## Verification

- Existing server test suite passes (expectations updated for the new WHERE clause).
- Live against **Mattermost 9.9.3**: an event created with `dt_start` **three minutes in the past** and `seconds=37` — unmatchable under the old rule — was announced **within 16s**, marked `processed` once, and produced **exactly one** post with no per-tick repeat.

Independent of #53, #54 and #55.