### PR TITLE
feat(server): optional announcement when a channel event is created

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -47,6 +47,13 @@
                 "help_text": "Business days for exp: '1,2,3,4,5' from mon to fri",
                 "default": "1,2,3,4,5",
                 "placeholder": "1"
+            },
+            {
+                "key": "AnnounceOnCreate",
+                "display_name": "Announce events in the channel when created",
+                "type": "bool",
+                "help_text": "When ON, scheduling an event with Channel visibility immediately posts it to that channel, in addition to the reminder posted when the event starts. Default OFF - the plugin has always been silent at creation time.",
+                "default": false
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -21,6 +21,13 @@ type configuration struct {
 	BusinessStartTime string
 	BusinessEndTime   string
 	BusinessDays      string
+
+	// AnnounceOnCreate posts to the event's channel as soon as a
+	// channel-visibility event is scheduled, in addition to the reminder the
+	// background job posts when the event starts. Opt-in: the plugin has always
+	// been silent at creation time, so defaulting this on would start posting in
+	// shared channels without anybody asking for it.
+	AnnounceOnCreate bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/event.go
+++ b/server/event.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -581,8 +582,52 @@ func (p *Plugin) CreateEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p.announceCreatedEvent(&event, user, loc)
+
 	apiResponse(w, &event)
 	return
+}
+
+// announceCreatedEvent posts to the event's channel when a channel-visibility
+// event is scheduled. Off unless AnnounceOnCreate is enabled.
+//
+// This is separate from the reminder the background job posts at start time: that
+// one says "this is happening now", this one says "this has been scheduled". A
+// failure here must never fail event creation — the event is already committed.
+func (p *Plugin) announceCreatedEvent(event *Event, user *model.User, loc *time.Location) {
+	if !p.getConfiguration().AnnounceOnCreate {
+		return
+	}
+	if event.Visibility != VisibilityChannel || event.Channel == nil {
+		return
+	}
+
+	color := DefaultColor
+	if event.Color != nil && *event.Color != "" {
+		color = *event.Color
+	}
+
+	start := event.Start.In(loc)
+	end := event.End.In(loc)
+	when := fmt.Sprintf("%s - %s", start.Format("Mon 02 Jan 15:04"), end.Format("15:04"))
+
+	text := fmt.Sprintf(":calendar: **%s**\n%s\nScheduled by @%s", event.Title, when, user.Username)
+	if event.Description != "" {
+		text = fmt.Sprintf("%s\n\n%s", text, event.Description)
+	}
+
+	post := &model.Post{
+		ChannelId: *event.Channel,
+		UserId:    p.BotId,
+	}
+	post.SetProps(model.StringInterface{
+		"attachments": []*model.SlackAttachment{{Text: text, Color: color}},
+	})
+
+	if _, postErr := p.API.CreatePost(post); postErr != nil {
+		// Log only: the event exists and the caller must still get a success.
+		p.API.LogError("announce on create failed: " + postErr.Error())
+	}
 }
 
 func (p *Plugin) RemoveEvent(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Motivation

The plugin is silent when an event is scheduled — the only channel post is the reminder the background job publishes when the event **starts**.

Users who pick **Channel** visibility often expect the channel to be told at booking time. Visibility only controls *who can see the event in their calendar*, which is easy to read as "post it to the channel". Real report that prompted this: *"no post in channel happened"* — from someone who had created a channel event hours before its start time and expected an announcement.

## Change

Adds `AnnounceOnCreate` (bool, **default false**). When enabled, creating an event with channel visibility also posts to that channel:

```
:calendar: **Team sync**
Wed 26 Aug 17:32 - 18:02
Scheduled by @rick

<description if present>
```

**Deliberately opt-in.** The plugin has always been silent at creation time, so defaulting this on would start posting into shared channels on upgrade without anybody asking for it.

## Scope guards

- Only fires when `visibility == channel` **and** a channel is set.
- A post failure only logs — the event row is already committed, so creation must still return success.
- Private/team events unaffected; the start-time reminder path is untouched.

## Verification

Against **Mattermost 9.9.3**:

| Setting | Visibility | Posts |
|---|---|---|
| OFF (default) | channel | 0 ✅ |
| ON | channel | exactly 1 ✅ |
| ON | private | 0 ✅ |

Server test suite passes. Independent of #53–#56.